### PR TITLE
Three issues resolved + new specs

### DIFF
--- a/lib/nexmo-jwt/jwt.rb
+++ b/lib/nexmo-jwt/jwt.rb
@@ -18,7 +18,7 @@ module Nexmo
       hash = {
         iat: iat,
         jti: generator.jti,
-        exp: generator.exp + generator.ttl,
+        exp: generator.exp || iat + generator.ttl,
         sub: generator.subject,
         application_id: generator.application_id,
         typ: typ

--- a/lib/nexmo-jwt/jwt_builder.rb
+++ b/lib/nexmo-jwt/jwt_builder.rb
@@ -42,18 +42,26 @@ module Nexmo
     attr_accessor :application_id, :private_key, :jti, :nbf, :ttl, :exp, :alg, :paths, :subject, :jwt
 
     def initialize(params = {})
+      Nexmo::JWTBuilder.validate_parameters_not_conflicting(params)
+
       @application_id = set_application_id(params.fetch(:application_id))
       @private_key = set_private_key(params.fetch(:private_key))
       @jti = params.fetch(:jti, SecureRandom.uuid)
       @nbf = params.fetch(:nbf, nil)
       @ttl = params.fetch(:ttl, 900)
-      @exp = params.fetch(:exp, 0)
+      @exp = params.fetch(:exp, nil)
       @alg = params.fetch(:alg, 'RS256')
       @paths = params.fetch(:paths, nil)
       @subject = params.fetch(:subject, 'Subject')
       @jwt = Nexmo::JWT.new(:generator => self)
 
       after_initialize!(self)
+    end
+
+    def self.validate_parameters_not_conflicting(params)
+      if params[:ttl] && params[:exp]
+        raise ArgumentError, "Expected either 'ttl' or 'exp' parameter, preference is to set 'ttl' parameter"
+      end
     end
 
     def after_initialize!(builder)


### PR DESCRIPTION
This pull request addresses three distinct issues:

* Sets `exp` parameter to equal either the `exp` value provided during configuration _or_ the `iat` and `ttl` parameters added together
* Sets the default `exp` parameter value to `nil` from `0`
* Validates that the user did not provide both `exp` and `ttl` parameters in the builder

Accounting for a user-provided `exp` parameter is necessary to maintain backward compatibility with the Nexmo Ruby SDK, which exposes the JWT generation parameters to the user to provide. As such, current users are accustomed to providing an `exp` parameter.

This pull request also adds additional tests for:

* When an `exp` parameter was provided that it includes that value for `exp`
* When an `exp` parameter is not provided it sets `exp` to 0
* When an `exp` parameter is not provided it sets the value for the token generation as `iat` + `ttl`
* When a user provides both `ttl` and `exp` in the builder instantiation it raises an `ArgumentError`