### PR TITLE
Migrate to Vonage SDK and code snippets

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2016-2020 Nexmo Inc
+Copyright 2020 Vonage
 
 Permission is hereby granted, free of charge, to any person
 obtaining a copy of this software and associated documentation

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Example providing custom configuration options:
 
 Nexmo Ruby JWT documentation: https://www.rubydoc.info/github/nexmo/nexmo-jwt
 
-Nexmo Ruby code examples: https://github.com/Nexmo/nexmo-ruby-code-snippets
+Nexmo Ruby code examples: https://github.com/Vonage/vonage-ruby-code-snippets
 
 Nexmo API reference: https://developer.nexmo.com/api
 


### PR DESCRIPTION
Library does not use the Ruby SDK so only changes are:

* Link to code snippets in README
* Copyright holder